### PR TITLE
ci: Test API against Node LTS versions

### DIFF
--- a/.github/workflows/continuous_delivery.yml
+++ b/.github/workflows/continuous_delivery.yml
@@ -40,11 +40,17 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node: [10, 12, 14]
+
     steps:
     - name: Project checkout
       uses: actions/checkout@v2
-    - name: Node.js Setup
+    - name: Node.js v${{ matrix.node }} Setup
       uses: actions/setup-node@v2.1.0
+      with:
+        node-version: ${{ matrix.node }}
     - name: Installation of Node.js dependencies
       run: npm ci
     - name: API Test

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -41,11 +41,17 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node: [10, 12, 14]
+
     steps:
     - name: Project checkout
       uses: actions/checkout@v2
-    - name: Node.js Setup
+    - name: Node.js v${{ matrix.node }} Setup
       uses: actions/setup-node@v2.1.0
+      with:
+        node-version: ${{ matrix.node }}
     - name: Installation of Node.js dependencies
       run: npm ci
     - name: API Test


### PR DESCRIPTION
## Description

This pull request intends to test the API against different Node versions. Also added the current version (v14, that is not an LTS yet).

> Production applications should only use Active LTS or Maintenance LTS releases.

### How can the user experience this change?

End-user will not be affected by this change.

## Related Issues

Related to #56

## PR Tasks

- [X] Has been related to an issue?
