### PR TITLE
ci: executar pipeline apenas em PR

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,9 +1,6 @@
 name: Continuous Integration
 
 on:
-  push:
-    branches-ignore:
-      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
Alteração feita pois ao abrir PR a pipeline estava sendo executada 2 vezes. Tanto para o push quanto para a abertura do PR.
Com essa alteração a pipeline será executada apenas para PR.
